### PR TITLE
Add About

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![alt text](demo.png)
 
-A workflow for [Alfred 3][1].
+A workflow for [Alfred][1].
 
 ## Download and Installation
 

--- a/src/info.plist
+++ b/src/info.plist
@@ -100,7 +100,7 @@
 		</dict>
 	</array>
 	<key>readme</key>
-	<string>Cal `ud` to search through Urban Dictionary definitions and ratings.</string>
+	<string>Call `ud` to search through Urban Dictionary definitions and ratings.</string>
 	<key>uidata</key>
 	<dict>
 		<key>A86052C6-254B-48B5-BA86-3B44B7883695</key>

--- a/src/info.plist
+++ b/src/info.plist
@@ -100,7 +100,7 @@
 		</dict>
 	</array>
 	<key>readme</key>
-	<string></string>
+	<string>Cal `ud` to search through Urban Dictionary definitions and ratings.</string>
 	<key>uidata</key>
 	<dict>
 		<key>A86052C6-254B-48B5-BA86-3B44B7883695</key>
@@ -119,7 +119,7 @@
 		</dict>
 	</dict>
 	<key>version</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>webaddress</key>
 	<string>https://github.com/xilopaint</string>
 </dict>


### PR DESCRIPTION
Workflows should have an About, even if short. This PR adds it and removes the specific mention to Alfred 3 (it works fine in 4).

Haven’t submitted the packaged `.alfredworkflow` because those changes are hidden.