### PR TITLE
Made it so results are sorted by like count

### DIFF
--- a/src/urban_dictionary.py
+++ b/src/urban_dictionary.py
@@ -32,6 +32,8 @@ def main(wf):  # pylint: disable=redefined-outer-name
     data = r.json()
 
     results = data["list"]
+    results = sorted(
+        results, key=lambda results: results['thumbs_up'], reverse=True)
 
     for result in results:
         word = result["word"]


### PR DESCRIPTION
When using the workflow I noticed that the results were essentially random in their like counts. This meant that some results were low quality and probably not the true definition.
I just added one line to make it so it is sorted by descending like counts as I thought it is a very useful feature.
During testing, I found that the results were much better quality as a result.